### PR TITLE
Make pytest case prototype work

### DIFF
--- a/tests/test_ctimer.py
+++ b/tests/test_ctimer.py
@@ -5,7 +5,7 @@
 import pytest
 
 
-from concentratetimer import ctimerdata
+from concentratetimer import concentratetimer
 
 
 @pytest.fixture


### PR DESCRIPTION
The prototype created by Cookiecutter does not work properly for the previous module naming refactoring. This pull request import the expected module.

# Steps to Test This PR
1. Go to `tests` folder
2. Execute `pytest .`

# Expected Behavior
```
$ pytest .
==================================================================== test session starts =====================================================================
platform linux -- Python 3.6.9, pytest-5.4.3, py-1.8.1, pluggy-0.13.1
rootdir: /home/tai271828/work-my-projects/li-projects/ctimer, inifile: setup.cfg
collected 1 item                                                                                                                                             

test_ctimer.py .                                                                                                                                       [100%]

===================================================================== 1 passed in 0.01s ======================================================================
```