### PR TITLE
build(setup.py): Remove the usage of pytest-runner and setup_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,6 @@ with open('HISTORY.rst') as history_file:
 
 requirements = [ ]
 
-setup_requirements = ['pytest-runner', ]
-
 test_requirements = ['pytest>=3', ]
 
 setup(
@@ -45,7 +43,6 @@ setup(
     keywords=['timer', 'concentration', 'concentrate'],
     name='concentratetimer',
     packages=find_packages(include=['concentratetimer', 'concentratetimer.*']),
-    setup_requires=setup_requirements,
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/zztin/ctimer',


### PR DESCRIPTION
## Types of changes
Please put an `x` in the box that applies

- [ ] **Bugfix**
- [ ] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [x] **setup.py**

## Description
pytest-runner is not suggested to use for security concern in pip. See
https://pypi.org/project/pytest-runner/ for more information. Besides,
using setup_requires is discouraged in favor of PEP-518. We may consider
to use pyproject.toml instead.

https://github.com/pypa/setuptools/issues/1684 and PEP 518

## Steps to Test This Pull Request
Steps to reproduce the behavior:
1. Pull the code change
2. `python setup.py install` or `python setup.py develop`


## Expected behavior
ctimer is installed and ready to use/develop.
