### PR TITLE
Ask Users to enter a goal upon starting a clock

### DIFF
--- a/concentratetimer/concentratetimer.py
+++ b/concentratetimer/concentratetimer.py
@@ -57,13 +57,6 @@ class ConcentrateTimer(tk.Frame):
         self.total_clock_aim.config(text=f"Aim: {self.data.aim_clock_count}")
         self.total_clock_counts = tk.Label(self, height=1, width=15, textvariable="")
         self.total_clock_counts.config(text=f"Done: {self.data.total_clock_count}")
-
-        # self.prompt_label = tk.Label(self,
-        #                              text="Goal for this clock:",
-        #                              height=1,
-        #                              width=15,
-        #                              textvariable="")
-        # self.prompt_entry = tk.Entry(self)
         self.goal_show_label = tk.Label(self, text="", height=2)
 
         self.date.grid(row=0, column=0, columnspan=2)
@@ -72,12 +65,8 @@ class ConcentrateTimer(tk.Frame):
         self.display.grid(row=3, column=0, columnspan=2)
         self.start_pause_button.grid(row=5, column=0)
         self.stop_button.grid(row=5, column=1)
-        # self.prompt_label.grid(row=4, column=0, columnspan=1)
-        # self.prompt_entry.grid(row=4, column=1, columnspan=1)
         self.goal_show_label.grid(row=6, column=0, columnspan=2)
-
-        # self.prompt_entry.bind("<Return>", (lambda event: self.get_goal()))
-        self.grid()
+        #self.grid()
 
     def get_goal(self):
         # TODO: get all goals for all clocks for the day

--- a/concentratetimer/concentratetimer.py
+++ b/concentratetimer/concentratetimer.py
@@ -66,15 +66,12 @@ class ConcentrateTimer(tk.Frame):
         self.start_pause_button.grid(row=5, column=0)
         self.stop_button.grid(row=5, column=1)
         self.goal_show_label.grid(row=6, column=0, columnspan=2)
-        #self.grid()
 
     def get_goal(self):
         # TODO: get all goals for all clocks for the day
         self.goal = simpledialog.askstring(title="Set your goals",
                                       prompt="What's your goal for this clock:")
         self.goal_show_label["text"] = f"Goal: {self.goal}"
-        # goal = self.prompt_entry.get()
-        # self.prompt_entry.delete(0,"end")
 
     def countdown(self):
         if self.clock_ticking:

--- a/concentratetimer/concentratetimer.py
+++ b/concentratetimer/concentratetimer.py
@@ -2,6 +2,7 @@ import shlex, subprocess
 import time
 from datetime import date
 import tkinter as tk
+from tkinter import simpledialog
 # TODO: check software licences
 # This code is an implementation upon the pomodoro technique from Cirillo, Francesco. If there is any ablation toward
 # their copyright, it is not our intention.
@@ -32,6 +33,7 @@ class ConcentrateTimer(tk.Frame):
         self.long_break_clock_count = self.data.long_break_clock_count
         self.pack()
         self.create_widgets()
+        self.goal = None
 
     def create_widgets(self):
         self.display = tk.Label(self, height=3, width=10, font=("Arial", 30), textvariable="")
@@ -55,12 +57,35 @@ class ConcentrateTimer(tk.Frame):
         self.total_clock_aim.config(text=f"Aim: {self.data.aim_clock_count}")
         self.total_clock_counts = tk.Label(self, height=1, width=15, textvariable="")
         self.total_clock_counts.config(text=f"Done: {self.data.total_clock_count}")
+
+        # self.prompt_label = tk.Label(self,
+        #                              text="Goal for this clock:",
+        #                              height=1,
+        #                              width=15,
+        #                              textvariable="")
+        # self.prompt_entry = tk.Entry(self)
+        self.goal_show_label = tk.Label(self, text="", height=2)
+
         self.date.grid(row=0, column=0, columnspan=2)
         self.total_clock_aim.grid(row=1, column=0, columnspan=2)
         self.total_clock_counts.grid(row=2, column=0, columnspan=2)
         self.display.grid(row=3, column=0, columnspan=2)
-        self.start_pause_button.grid(row=4, column=0)
-        self.stop_button.grid(row=4, column=1)
+        self.start_pause_button.grid(row=5, column=0)
+        self.stop_button.grid(row=5, column=1)
+        # self.prompt_label.grid(row=4, column=0, columnspan=1)
+        # self.prompt_entry.grid(row=4, column=1, columnspan=1)
+        self.goal_show_label.grid(row=6, column=0, columnspan=2)
+
+        # self.prompt_entry.bind("<Return>", (lambda event: self.get_goal()))
+        self.grid()
+
+    def get_goal(self):
+        # TODO: get all goals for all clocks for the day
+        self.goal = simpledialog.askstring(title="Set your goals",
+                                      prompt="What's your goal for this clock:")
+        self.goal_show_label["text"] = f"Goal: {self.goal}"
+        # goal = self.prompt_entry.get()
+        # self.prompt_entry.delete(0,"end")
 
     def countdown(self):
         if self.clock_ticking:
@@ -106,7 +131,7 @@ class ConcentrateTimer(tk.Frame):
                 message = f"Beebeebeebee beebee. Done. You have achieved {self.data.total_clock_count} " \
                           f"clocks today. Enjoy your break."
         elif message_type == "start":
-            message = "ready? go"
+            message = "ready? set your goal."
         elif message_type == "pause":
             message = "Pause"
         elif message_type == "stop":
@@ -120,6 +145,8 @@ class ConcentrateTimer(tk.Frame):
         # start clock
         if self.clock_ticking == False:
             self.voice_message("start")
+            if self.remaining_time == self.set_time:
+                self.get_goal()
             self.data.start_time_first_clock = time.time()
             self.data.start_time_this_clock = time.time()
             self.start_pause_button['text'] = "Pause"


### PR DESCRIPTION
prompt users to enter a goal for the current clock when starting a new clock.

## Types of changes
Please put an `x` in the box that applies

- [ ] **Bugfix**
- [x] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description
**Describe what the change is**
Add an extra window when "start" is clicked to ask user to input their goal of the clock. While "ok" is clicked, the goal is shown in the last row of the main ctimer window. 


## Steps to Test This Pull Request
Steps to reproduce the behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See error

## Expected behavior
A clear and concise description of what you expected to happen.

## Related Issue
If applicable, refernce to the issue related to this pull request.

## More Information
**Screenshots**
If applicable, add screenshots to help explain your problem.

**Additional context**
Add any other context about the problem here. You may also want to refer
to [how to wirte the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)
