### PR TITLE
feat(get_goal): Force to input goal on starting a clock

### DIFF
--- a/concentratetimer/concentratetimer.py
+++ b/concentratetimer/concentratetimer.py
@@ -70,8 +70,13 @@ class ConcentrateTimer(tk.Frame):
     def get_goal(self):
         # TODO: get all goals for all clocks for the day
         self.goal = simpledialog.askstring(title="Set your goals",
-                                      prompt="What's your goal for this clock:")
+                                           prompt="What's your goal for this clock:")
+        while not self.goal:
+            self.goal = simpledialog.askstring(title="Set Your Goals",
+                                               prompt="Empty Goal Is Not Allow. What's Your Goal for This Clock:")
+
         self.goal_show_label["text"] = f"Goal: {self.goal}"
+
 
     def countdown(self):
         if self.clock_ticking:
@@ -131,6 +136,7 @@ class ConcentrateTimer(tk.Frame):
         # start clock
         if self.clock_ticking == False:
             self.voice_message("start")
+            # only asking when the clock starts at the very beginning
             if self.remaining_time == self.set_time:
                 self.get_goal()
             self.data.start_time_first_clock = time.time()


### PR DESCRIPTION
## Types of changes
Please put an `x` in the box that applies

- [ ] **Bugfix**
- [x] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description
When starting a clock, force users to input a goal. Empty goal is not allowed.

## Steps to Test This Pull Request
Steps to reproduce the behavior:
1. Click Start to start a clock
2. `Click OK without inputting any text`, or `click cancel`. 
3. When prompting `empty goal is not allowed`, keep `Click OK without inputting any text`, or `click cancel`.
4. After repeating step3 for 5 times, input some texts and click OK

## Expected behavior
A clock only starts when there is input in the goal prompt box.
