### PR TITLE
Draft database for storing goals and descriptions. Bugs in subwindow launching. #12

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,9 @@ Features
         - Allows notes taking during the clock (note interruption, how many pauses you took etc.)
         - Add tick-tock sound when clocks start.
 
-# Note: For checking the sqlite database in command line:
+# Note: For checking the sqlite database
+A. drag and drop: https://inloop.github.io/sqlite-viewer/
+B. in command line
 1. >>> sqlite3 ./data/ctimer.db
 2. >>> select * from clock_details; <---remember the ";" in the end
 The entries should show! If not, try

--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,7 @@ Features
 * Provide a Tkinter GUI window for the ease of use for users.
 * Set 25 mins for focus time, and 5 mins for break time.
 * Set 8 clocks as aim for a day.
+* Goals / feedback of each clock & time span per day is kept in a local SQL database (named ctimer.db). Use command line tool sqlite3 you could check the entries.
 
 * TODO BUGFIX:
         - self.display.config updates appears after the voice_messages (os.subprocess("say ...")
@@ -40,6 +41,12 @@ Features
         - Allows notes taking during the clock (note interruption, how many pauses you took etc.)
         - Add tick-tock sound when clocks start.
 
+# Note: For checking the sqlite database in command line:
+1. >>> sqlite3 ./data/ctimer.db
+2. >>> select * from clock_details; <---remember the ";" in the end
+The entries should show! If not, try
+3. .tables
+This should show clock_details
 
 Installation
 ------------

--- a/concentratetimer/cli.py
+++ b/concentratetimer/cli.py
@@ -1,13 +1,19 @@
 """Console script for concentratetimer."""
 from concentratetimer import concentratetimer
 import tkinter as tk
+import concentratetimer.ctimer_db as db
+
 import sys
 
 
 def main():
+    db_file = '../data/ctimer.db'
+    db.create_table(db_file) # create if not exist
     root = tk.Tk()
     app = concentratetimer.ConcentrateTimer(master=root)
     app.mainloop()
+
+
     return 0
 
 

--- a/concentratetimer/cli.py
+++ b/concentratetimer/cli.py
@@ -2,12 +2,13 @@
 from concentratetimer import concentratetimer
 import tkinter as tk
 import concentratetimer.ctimer_db as db
-
 import sys
-
+from subprocess import Popen, PIPE
+import os
 
 def main():
-    db_file = './data/ctimer.db'
+    path = os.path.dirname(concentratetimer.__file__).rsplit("/",1)[0]
+    db_file = f"{path}/data/ctimer.db"
     db.create_connection(db_file) # create if not exist
     root = tk.Tk()
     app = concentratetimer.ConcentrateTimer(master=root, db_file=db_file)

--- a/concentratetimer/cli.py
+++ b/concentratetimer/cli.py
@@ -7,10 +7,10 @@ import sys
 
 
 def main():
-    db_file = '../data/ctimer.db'
+    db_file = './data/ctimer.db'
     db.create_connection(db_file) # create if not exist
     root = tk.Tk()
-    app = concentratetimer.ConcentrateTimer(master=root)
+    app = concentratetimer.ConcentrateTimer(master=root, db_file=db_file)
     app.mainloop()
 
 

--- a/concentratetimer/cli.py
+++ b/concentratetimer/cli.py
@@ -8,7 +8,7 @@ import sys
 
 def main():
     db_file = '../data/ctimer.db'
-    db.create_table(db_file) # create if not exist
+    db.create_connection(db_file) # create if not exist
     root = tk.Tk()
     app = concentratetimer.ConcentrateTimer(master=root)
     app.mainloop()

--- a/concentratetimer/concentratetimer.py
+++ b/concentratetimer/concentratetimer.py
@@ -3,6 +3,8 @@ import time
 from datetime import date
 import tkinter as tk
 from tkinter import simpledialog
+import concentratetimer.ctimer_db as db
+from tkinter import StringVar
 # TODO: check software licences
 # This code is an implementation upon the pomodoro technique from Cirillo, Francesco. If there is any ablation toward
 # their copyright, it is not our intention.
@@ -21,8 +23,8 @@ class ConcentrateTimer(tk.Frame):
         self.master = master
         master.title("Pomodoro Timer")
         self.test_volume()
-        #self.data = Meta(set_time=2, break_time=2, long_break_time=5, long_break_clock_count=2)
-        self.data = Meta()
+        self.data = Meta(set_time=1, break_time=2, long_break_time=5, long_break_clock_count=2)
+#        self.data = Meta()
         self.clock_ticking = False
         self.is_break = False
         self.set_time = self.data.set_time
@@ -34,6 +36,7 @@ class ConcentrateTimer(tk.Frame):
         self.pack()
         self.create_widgets()
         self.goal = None
+        self.clock_details = None
 
     def create_widgets(self):
         self.display = tk.Label(self, height=3, width=10, font=("Arial", 30), textvariable="")
@@ -81,11 +84,48 @@ class ConcentrateTimer(tk.Frame):
 
     def get_goal(self):
         # TODO: get all goals for all clocks for the day
-        self.goal = simpledialog.askstring(title="Set your goals",
+        self.clock_details.goal = simpledialog.askstring(title="Set your goals",
                                       prompt="What's your goal for this clock:")
-        self.goal_show_label["text"] = f"Goal: {self.goal}"
-        # goal = self.prompt_entry.get()
-        # self.prompt_entry.delete(0,"end")
+        self.goal_show_label["text"] = f"Goal: {self.clock_details.goal}"
+
+    def ask_reached_goal_reason(self):
+        global reached
+        reached = tk.Toplevel()
+        reached.wm_title("Assess your clock")
+        l = tk.Label(reached, text="Did you reach your goal, why?", height = 2)
+        l.grid(row=0, column=0, columnspan=2)
+        yes = tk.Button(reached, text="Yes", command=self.goal_reached)
+        yes.grid(row=1, column=0, columnspan=1)
+        no = tk.Button(reached, text="Not yet", command=self.goal_not_reached)
+        no.grid(row=1, column=1, columnspan=1)
+        prompt_label = tk.Label(reached,
+                                     text="Reasons:",
+                                     height=1,
+                                     width=5)
+        global r
+        r = StringVar()
+        r.set("e.g. planned too little time")
+        # TODO: show reason prompt entry after clicking (yes, no)
+        prompt_entry = tk.Entry(reached, textvariable=r)
+
+        def get_reason(event):
+            reason = r.get()
+            print(reason)
+            reached.destroy()
+            self.clock_details.reason = reason
+            print("in def get_reason", self.clock_details)
+
+        prompt_entry.bind("<Return>", get_reason)
+        prompt_label.grid(row=2, column=0, columnspan=1)
+        prompt_entry.grid(row=2, column=1, columnspan=1)
+
+    def goal_reached(self):
+        # TODO: pass the button in here, change color upon clicking.
+        self.clock_details.reached_bool = True
+
+    def goal_not_reached(self):
+        # TODO: pass the button in here, change color upon clicking.
+        self.clock_details.reached_bool = False
 
     def countdown(self):
         if self.clock_ticking:
@@ -94,11 +134,15 @@ class ConcentrateTimer(tk.Frame):
                 self.display.config(text=time_print(self.remaining_time))
             else:
                 self.remaining_time = 0
-                # TODO: self.display.config updates appears after the voice_messages (os.subprocess("say ..."))
-                # TODO: 00:00 does not show.
+                # Finish a clock
                 if self.is_break == False:
                     self.display.config(text="Done!")
                     self.data.total_clock_count += 1
+                    self.clock_details.clock_count = self.data.total_clock_count
+                    self.clock_details.end_clock = time.time()
+                    self.ask_reached_goal_reason()
+                    #
+                    print(self.clock_details)
                     self.total_clock_counts.config(text=f"Total clocks: {self.data.total_clock_count}")
                     if self.data.total_clock_count % self.long_break_clock_count == 0:
                         self.remaining_time = self.set_long_break_time
@@ -108,7 +152,10 @@ class ConcentrateTimer(tk.Frame):
                     self.is_break = True
                     self.display['fg'] = "Green"
                 else:
+                    # break is over. Record break over time.
                     self.voice_message("break_over")
+                    self.clock_details.end_break = time.time()
+                    db.db_add_clock_details(self.clock_details)
                     self.is_break = False
                     self.remaining_time = self.set_time
                     self.display.config(text=time_print(self.set_time))
@@ -131,7 +178,8 @@ class ConcentrateTimer(tk.Frame):
                 message = f"Beebeebeebee beebee. Done. You have achieved {self.data.total_clock_count} " \
                           f"clocks today. Enjoy your break."
         elif message_type == "start":
-            message = "ready? set your goal."
+            # TODO: if starting a new clock, new message: ready? set your goal
+            message = "ready? Start."
         elif message_type == "pause":
             message = "Pause"
         elif message_type == "stop":
@@ -142,13 +190,15 @@ class ConcentrateTimer(tk.Frame):
         subprocess.run(command)
 
     def start_pause(self):
-        # start clock
         if self.clock_ticking == False:
             self.voice_message("start")
+            ### starting a new clock
             if self.remaining_time == self.set_time:
+                self.clock_details = db.Clock_details()
+                self.clock_details.date = f"{date.today()}"
+                self.clock_details.start_clock = time.time()
                 self.get_goal()
-            self.data.start_time_first_clock = time.time()
-            self.data.start_time_this_clock = time.time()
+            self.clock_details.start_clock = time.time()
             self.start_pause_button['text'] = "Pause"
             self.start_pause_button['fg'] = "Red"
             self.clock_ticking = True
@@ -179,6 +229,8 @@ class ConcentrateTimer(tk.Frame):
               "If not, check your volume and sound system. \n"
               "This is essential for getting notice from pomodoro when time's up. \n"
               "Also, find PomodroTimer GUI window somewhere and interact there. :)")
+
+
 
 
 class Meta():

--- a/concentratetimer/concentratetimer.py
+++ b/concentratetimer/concentratetimer.py
@@ -218,10 +218,6 @@ class ConcentrateTimer(tk.Frame):
         print(message)
         command = shlex.split(f"say {message}")
         subprocess.run(command)
-        print("Did you hear something? \n"
-              "If not, check your volume and sound system. \n"
-              "This is essential for getting notice from pomodoro when time's up. \n"
-              "Also, find PomodroTimer GUI window somewhere and interact there. :)")
 
 
 

--- a/concentratetimer/concentratetimer.py
+++ b/concentratetimer/concentratetimer.py
@@ -18,8 +18,9 @@ def time_print(time):
 
 
 class ConcentrateTimer(tk.Frame):
-    def __init__(self, master=None):
+    def __init__(self, master=None, db_file=None):
         super().__init__(master)
+        self.db_file = db_file
         self.master = master
         master.title("Pomodoro Timer")
         self.test_volume()
@@ -99,7 +100,6 @@ class ConcentrateTimer(tk.Frame):
         prompt_entry.bind("<Return>", self.get_reason)
         prompt_label.grid(row=2, column=0, columnspan=1)
         prompt_entry.grid(row=2, column=1, columnspan=1)
-        print("in def ask_reached_goal_reason", self.clock_details)
 
     def get_reason(self, event):
         reason = r.get()
@@ -145,9 +145,8 @@ class ConcentrateTimer(tk.Frame):
                     # break is over. Record break over time.
                     self.voice_message("break_over")
                     self.clock_details.end_break = time.time()
-                    # BUG: This is reached before reason is filled. check line 142 todo
-                    print("line 155 in concentrationtimer.py before writing:", self.clock_details)
-                    db.db_add_clock_details(self.clock_details)
+                    # TODO: Bug fix --This is reached before reason is filled. check line 142
+                    db.db_add_clock_details(self.db_file, self.clock_details)
                     self.is_break = False
                     self.remaining_time = self.set_time
                     self.display.config(text=time_print(self.set_time))

--- a/concentratetimer/ctimer_db.py
+++ b/concentratetimer/ctimer_db.py
@@ -2,17 +2,19 @@ import sqlite3
 from sqlite3 import Error
 from collections import namedtuple
 from dataclasses import dataclass
+from dataclasses import astuple
 
 
 @dataclass(init=True, repr=True)
 class Clock_details:
-    date: str = "",
-    clock_count: int = 0,
-    start_clock: float = 12345.6,
-    end_clock: float = 12345.6,
-    end_break: float = 12345.6,
-    goal: str = "GOAL TO BE SET",
-    reached_bool: bool = False,
+    date: str = ""
+    clock_count: int = 0
+    start_clock: float = 12345.6
+    end_clock: float = 12345.6
+    end_break: float = 12345.7
+    task_title: str = "Task title TO BE IMPLEMENT"
+    task_description: str = "Task description to be set"
+    reached_bool: bool = False
     reason: str = "REASON TO BE FILLED IN"
 
 
@@ -21,9 +23,7 @@ def db_add_clock_details(clock_instance):
     # create a database connection
     conn = create_connection(db_file)
     with conn:
-        # TODO: fix AttributeError: 'Clock_details' object has no attribute 'astuple'
-        # https://docs.python.org/3/library/dataclasses.html
-        clock_id = create_clock_details(conn, clock_instance.astuple())
+        clock_id = create_clock_details(conn, astuple(clock_instance))
     conn.close()
     return clock_id
 

--- a/concentratetimer/ctimer_db.py
+++ b/concentratetimer/ctimer_db.py
@@ -96,6 +96,3 @@ def create_connection_new(db_file):
             conn.close()
 
 
-if __name__ == '__main__':
-    create_connection("./data/ctimer.db")
-

--- a/concentratetimer/ctimer_db.py
+++ b/concentratetimer/ctimer_db.py
@@ -1,0 +1,83 @@
+import sqlite3
+from sqlite3 import Error
+from collections import namedtuple
+from dataclasses import dataclass
+
+
+@dataclass(init=True, repr=True)
+class Clock_details:
+    date: str = "",
+    clock_count: int = 0,
+    start_clock: float = 12345.6,
+    end_clock: float = 12345.6,
+    end_break: float = 12345.6,
+    goal: str = "GOAL TO BE SET",
+    reached_bool: bool = False,
+    reason: str = "REASON TO BE FILLED IN"
+
+
+def db_add_clock_details(clock_instance):
+    db_file = "../data/ctimer.db"
+    # create a database connection
+    conn = create_connection(db_file)
+    with conn:
+        # TODO: fix AttributeError: 'Clock_details' object has no attribute 'astuple'
+        # https://docs.python.org/3/library/dataclasses.html
+        clock_id = create_clock_details(conn, clock_instance.astuple())
+    conn.close()
+    return clock_id
+
+
+def create_table(db_file):
+    """ create a table from nothing
+    """
+    try:
+        conn = sqlite3.connect(db_file)
+        c = conn.cursor()
+        # Create table
+        c.execute('''CREATE TABLE IF NOT EXISTS clock_details
+                     (id integer PRIMARY KEY,
+                     date text,
+                     clock_count integer,
+                     start_clock text,
+                     end_clock text,
+                     end_break text,
+                     task_title text,
+                     task_description text,
+                     reached_bool text,
+                     reason text )''')
+        conn.commit()
+        conn.close()
+    except Error as e:
+        print(e)
+
+
+def create_connection(db_file):
+    """ create a database connection to the SQLite database
+        specified by db_file
+    :param db_file: database file
+    :return: Connection object or None
+    """
+    conn = None
+    try:
+        conn = sqlite3.connect(db_file)
+    except Error as e:
+        print(e)
+
+    return conn
+
+
+def create_clock_details(conn, entry):
+    """
+    Create a new clock detail entry into the clock_details table
+    :param conn: connection
+    :param entry:
+    :return: clock id
+    """
+    # Insert a row of data
+    sql = '''INSERT INTO clock_details(date, clock_count, start_clock, end_clock, end_break, task_title, 
+    task_description, reached_bool, reason) VALUES (?,?,?,?,?,?,?,?,?)'''
+    #TODO: add pause interval
+    cur = conn.cursor()
+    cur.execute(sql, entry)
+    return cur.lastrowid

--- a/concentratetimer/ctimer_db.py
+++ b/concentratetimer/ctimer_db.py
@@ -18,8 +18,7 @@ class Clock_details:
     reason: str = "REASON TO BE FILLED IN"
 
 
-def db_add_clock_details(clock_instance):
-    db_file = "../data/ctimer.db"
+def db_add_clock_details(db_file, clock_instance):
     # create a database connection
     conn = create_connection(db_file)
     with conn:
@@ -82,4 +81,21 @@ def create_clock_details(conn, entry):
     cur = conn.cursor()
     cur.execute(sql, entry)
     return cur.lastrowid
+
+
+def create_connection_new(db_file):
+    """ create a database connection to a SQLite database """
+    conn = None
+    try:
+        conn = sqlite3.connect(db_file)
+        print(sqlite3.version)
+    except Error as e:
+        print(e)
+    finally:
+        if conn:
+            conn.close()
+
+
+if __name__ == '__main__':
+    create_connection("./data/ctimer.db")
 

--- a/concentratetimer/ctimer_db.py
+++ b/concentratetimer/ctimer_db.py
@@ -61,6 +61,7 @@ def create_connection(db_file):
     conn = None
     try:
         conn = sqlite3.connect(db_file)
+        create_table(db_file)
     except Error as e:
         print(e)
 
@@ -81,3 +82,4 @@ def create_clock_details(conn, entry):
     cur = conn.cursor()
     cur.execute(sql, entry)
     return cur.lastrowid
+


### PR DESCRIPTION
## Types of changes
Please put an `x` in the box that applies

- [ ] **Bugfix**
- [x] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description
**Describe what the change is**
Record the goals and review into local database.
## Steps to Test This Pull Request
Steps to reproduce the behavior:
1. type ctimer to command line to initiate ctimer
2. enter a goal for the clock. 
3. Start a clock
4. when a clock ends, click if you finish your goal and enter reasons for why you did or did not finish the goal. (currently the clock is set to very short for testing)
6. Use commandline sqlite to check the recorded entries of the clock.

## Expected behavior
The info is stored in the ctimer.db in the data folder.

## Current Issue NOT Solved
Now the subwindow to allow entering the reasons does not halt the main window. therefore the break could start and finish before the reason is entered. When this happens, the reasons are not recorded in the database. 

## Related issue
Address #12 feature request
