### PR TITLE
Safe closing

### DIFF
--- a/ctimer/cli.py
+++ b/ctimer/cli.py
@@ -6,6 +6,7 @@ import sys
 import os
 import argparse
 from ctimer.visual import show_stats as ss
+from tkinter import messagebox
 
 
 
@@ -37,16 +38,7 @@ def main():
     elif args.stats:
         ss.plot_timetable(path=db_file, outpath=f"{path}/data/")
     else:
-        root = tk.Tk()
-        if args.hide is False:
-            root.attributes("-topmost", True)
-        app = ctimer.ConcentrateTimer(master=root,
-                                      db_file=db_file,
-                                      debug=args.debug,
-                                      hide=args.hide,
-                                      silence=args.silence)
-        app.mainloop()
-        return 0
+        ctimer.maintk(db_file, hide=args.hide, debug=args.debug, silence=args.silence)
 
 
 if __name__ == "__main__":

--- a/ctimer/ctimer.py
+++ b/ctimer/ctimer.py
@@ -8,6 +8,26 @@ import ctimer.ctimer_db as db
 # This code is an implementation upon the pomodoro technique from Cirillo, Francesco. If there is any ablation toward
 # their copyright, it is not our intention.
 
+
+def maintk(db_file, hide=False, debug=False, silence=False):
+    root = tk.Tk()
+
+    def on_closing():
+        if mbox.askokcancel("Quit", "Do you want to quit?"):
+            root.destroy()
+
+    root.protocol("WM_DELETE_WINDOW", on_closing)
+    if hide is False:
+        root.attributes("-topmost", True)
+    ConcentrateTimer(master=root,
+                     db_file=db_file,
+                     debug=debug,
+                     hide=hide,
+                     silence=silence).pack()
+    root.mainloop()
+    return 0
+
+
 def time_print(time):
     mins, secs = divmod(time, 60)
     print_time = '{:02d}:{:02d}'.format(mins, secs)
@@ -43,6 +63,8 @@ class ConcentrateTimer(tk.Frame):
         self.clock_details = db.Clock_details()
         self.clock_details.clock_count = db.get_clock_count(self.db_file)
         self.total_clock_counts.config(text=f"Done: {self.clock_details.clock_count}")
+        # master.protocol("WM_DELETE_WINDOW", on_closing)
+
 
     def bring_to_front(self):
         self.master.attributes('-topmost', 1)
@@ -236,17 +258,6 @@ class ConcentrateTimer(tk.Frame):
         command = shlex.split(f"say {message}")
         subprocess.run(command)
 
-    # def on_closing(self):
-    #     if self.is_break:
-    #         # premature end break
-    #         self.clock_details.end_break = time.time()
-    #     else:
-    #         if self.clock_ticking:
-    #             # premature end clock
-    #             self.clock_details.end_clock = time.time()
-    #         else:
-    #             pass
-    #     return True
 
 class Meta():
     def __init__(self,


### PR DESCRIPTION
(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)

## Types of changes
Please put an `x` in the box that applies

- [x] **Bugfix**
- [x] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description
Fix the bug when windows are halt during a clock or during break, it won't be recorded. 
Now it will be recorded even when the clock is ticking. The end clock time will be the time when the window is closed. A clock could last < 25 mins.

## Steps to Test This Pull Request
Steps to reproduce the behavior:
1. `ctimer --debug`
2. Test a few clocks when you end during ticking, during a break, and after a  break. 
3. Check ctimer.db file
4. See if it act as expected.

