### PR TITLE
fix(view): use expected instance and fix corresponding interface for fake clock

### DIFF
--- a/ctimer/view.py
+++ b/ctimer/view.py
@@ -72,7 +72,6 @@ class CtimerClockViewBase:
         """
         Abstract method of showing time_text and total_clock_counts with labels
 
-        :param time_text: the time text you want to show
         :param total_clock_counts: the total clock counts you want to show
         """
         raise NotImplementedError
@@ -363,9 +362,9 @@ class CtimerClockView(tk.Frame, CtimerClockViewBase):
         if not self.tm.clock_details.is_break and not self.tm.fresh_new:
             self.tm.clock_details.reached_bool, self.tm.clock_details.reason = self.ask_reached_goal_reason()
             if self.tm.clock_details.reached_bool:
-                self.clock_details.clock_count += 1
-                self.tv.countdown_display("Done!", self.tm.clock_details.is_break)
-                self.tv.show_clock_count(self.tm.clock_details.clock_count)
+                self.tm.clock_details.clock_count += 1
+                self.countdown_display("Done!", self.tm.clock_details.is_break)
+                self.show_clock_count(self.tm.clock_details.clock_count)
                 # only if goal is reached, clock count is +1, we want to ask if it is a complete (no break) clock
                 self.tm.check_complete()
         # Write to clock details even if it is terminated. (goal not reached)
@@ -428,7 +427,7 @@ class CtimerClockFakeView(CtimerClockView):
         self._show_gui_window_response("Widgets are created and arranged by the layout.")
 
 
-    def show_clock_count(self, time_text, total_clock_counts):
+    def show_clock_count(self, total_clock_counts):
         self._show_gui_window_response(f"total_clock_counts: {total_clock_counts}")
         self._label_total_clock_counts = total_clock_counts
 


### PR DESCRIPTION
## Types of changes
<!--Please remove the types that does not apply to this change-->
- **Bugfix**
- **Breaking change** (any change that would cause existing functionality to not work as expected)


## Description
<!--Describe what the change is**-->
1. Fix-up and use correct instances of model and view
2. Fix-up CI

## Checklist:
- [ ] Add test cases to all the changes you introduce
- [x] Run `pytest` locally
- [x] Update the documentation if necessary

## Steps to Test This Pull Request
<!--
Steps to reproduce the behavior:
1. ...
2. ...
3. ...
-->
1. Use the clock as usual
2. Wait for the clock bumpping

## Expected behavior
<!--A clear and concise description of what you expected to happen-->
Clock counting field bumps


## Related Issue
<!--If applicable, refernce to the issue related to this pull request.-->
issue: 63
